### PR TITLE
Adds Minimum-Score config option for Themis

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
 		<dependency>
 			<groupId>com.github.Jumper251</groupId>
 			<artifactId>AdvancedReplay</artifactId>
-			<version>master-SNAPSHOT</version>
+			<version>-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/src/main/java/me/justindevb/anticheatreplay/AntiCheatReplay.java
+++ b/src/main/java/me/justindevb/anticheatreplay/AntiCheatReplay.java
@@ -274,6 +274,7 @@ public class AntiCheatReplay extends JavaPlugin {
         List<String> list = new ArrayList<>();
         list.add("notify");
         getConfig().addDefault("Themis.Disabled-Actions", list);
+        getConfig().addDefault("Themis.Minimum-Score", 5.0);
     }
 
     @SuppressWarnings("unused")

--- a/src/main/java/me/justindevb/anticheatreplay/listeners/AntiCheats/ThemisListener.java
+++ b/src/main/java/me/justindevb/anticheatreplay/listeners/AntiCheats/ThemisListener.java
@@ -3,6 +3,7 @@ package me.justindevb.anticheatreplay.listeners.AntiCheats;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.gmail.olexorus.themis.api.ThemisApi;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -18,6 +19,7 @@ import me.justindevb.anticheatreplay.AntiCheatReplay;
 public class ThemisListener extends ListenerBase implements Listener {
 	
 	private List<String> disabledActions = new ArrayList<>();
+	private double minimumScore;
 
 	public ThemisListener(AntiCheatReplay acReplay) {
 		super(acReplay);
@@ -32,6 +34,9 @@ public class ThemisListener extends ListenerBase implements Listener {
 
 	@EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
 	public void onViolationEvent(ViolationEvent event) {
+		// If the score is less than the minimum ignore the event
+		if (ThemisApi.getViolationScore(event.getPlayer(), event.getType()) < minimumScore) return;
+
 		Player p = event.getPlayer();
 
 		if (alertList.contains(p.getUniqueId()))
@@ -56,6 +61,7 @@ public class ThemisListener extends ListenerBase implements Listener {
 
 	private void initThemisSpecificConfig() {
 		this.disabledActions = acReplay.getConfig().getStringList("Themis.Disabled-Actions");
+		this.minimumScore = acReplay.getConfig().getDouble("Themis.Minimum-Score", 5.0);
 	}
 
 }


### PR DESCRIPTION
Adds a Minimum-Score option to the Themis specific configuration. This prevents a new recording from repeatedly being started all the time.

Also updated the dependency for AdvancedReplay.

If anyone's interested, here is the jar file in case this doesn't ever get merged.
[AntiCheatReplay-2.7.8-d481be2.zip](https://github.com/JustinDevB/AntiCheatReplay/files/13746612/AntiCheatReplay-2.7.8-d481be2.zip)