### PR TITLE
Config option to keep plugin enabled if no anticheat is found

### DIFF
--- a/src/main/java/me/justindevb/anticheatreplay/AntiCheatReplay.java
+++ b/src/main/java/me/justindevb/anticheatreplay/AntiCheatReplay.java
@@ -83,7 +83,7 @@ public class AntiCheatReplay extends JavaPlugin {
             }
         }
 
-        if (activeListeners.isEmpty()) {
+        if (activeListeners.isEmpty() && !getConfig().getBoolean(Keep-Enabled-With-No-Anticheat)) {
             disablePlugin();
         }
     }
@@ -311,6 +311,7 @@ public class AntiCheatReplay extends JavaPlugin {
         config.addDefault("General.Always-Save-Recording", false);
         config.addDefault("General.Report-Cooldown", 3);
         config.addDefault("General.Report-Enabled", true);
+        config.addDefault("Keep-Enabled-With-No-Anticheat", false);
     }
 
     /**


### PR DESCRIPTION
Useful if your anticheat doesn't work at the moment but you still want people to be able to use the /report command