### PR TITLE
Fix recordings failing after first anticheat trigger

### DIFF
--- a/src/main/java/me/justindevb/anticheatreplay/ListenerBase.java
+++ b/src/main/java/me/justindevb/anticheatreplay/ListenerBase.java
@@ -7,10 +7,10 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Random;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.TimeUnit;
 
 import me.justindevb.anticheatreplay.api.events.WebhookSendEvent;
@@ -51,8 +51,8 @@ public abstract class ListenerBase {
 	private int BLUE = 0;
 
 
-	protected LinkedList<UUID> alertList = new LinkedList<>();
-	protected LinkedList<UUID> punishList = new LinkedList<>();
+	protected ConcurrentLinkedDeque<UUID> alertList = new ConcurrentLinkedDeque<>();
+	protected ConcurrentLinkedDeque<UUID> punishList = new ConcurrentLinkedDeque<>();
 
 	public ListenerBase(AntiCheatReplay acReplay) {
 		this.acReplay = acReplay;
@@ -84,7 +84,7 @@ public abstract class ListenerBase {
 
 		acReplay.log("Starting recording of player: " + p.getName(), false);
 		acReplay.getFoliaLib().getScheduler().runNextTick(task -> {
-			replay.startRecording(replayName, List.of(getNearbyPlayers(p)), Math.toIntExact(delay * 60));
+			replay.startRecording(replayName, List.of(getNearbyPlayers(p)), 0);
 		});
 
 
@@ -129,9 +129,10 @@ public abstract class ListenerBase {
 		long loginTime = cachedPlayer.getLoginTimeStamp();
 
 		acReplay.getFoliaLib().getScheduler().runLaterAsync(() -> {
+			try {
 				if (ALWAYS_SAVE_RECORDING)
 					punishList.add(p.getUniqueId());
-				if (!p.isOnline() || p == null) {
+				if (p == null || !p.isOnline()) {
 					if (SAVE_ON_DISCONNECT)
 						punishList.add(p.getUniqueId());
 				}
@@ -150,7 +151,6 @@ public abstract class ListenerBase {
 					acReplay.log("Saving recording of attempted hack...", false);
 					acReplay.log("Saved as: " + replayName, false);
 					sendDiscordWebhook(replayName, p, getOnlineTime(loginTime, System.currentTimeMillis()));
-					punishList.remove(p.getUniqueId());
 
 					if (notifyStaff) {
 						String notification = Messages.NOTIFY_RECORDING;
@@ -161,15 +161,14 @@ public abstract class ListenerBase {
 						}
 					}
 
-					if (alertList.contains(p.getUniqueId()))
-						alertList.remove(p.getUniqueId());
-
 				} else {
 					replay.stopRecording(replayName, false);
-					if (alertList.contains(p.getUniqueId()))
-						alertList.remove(p.getUniqueId());
 					acReplay.log("Not saving recording...", false);
 				}
+			} finally {
+				alertList.remove(p.getUniqueId());
+				punishList.remove(p.getUniqueId());
+			}
 	},20L * 60L * delay);
 	}
 

--- a/src/main/java/me/justindevb/anticheatreplay/listeners/AntiCheats/GrimACListener.java
+++ b/src/main/java/me/justindevb/anticheatreplay/listeners/AntiCheats/GrimACListener.java
@@ -3,8 +3,6 @@ package me.justindevb.anticheatreplay.listeners.AntiCheats;
 
 import ac.grim.grimac.api.GrimAbstractAPI;
 import ac.grim.grimac.api.GrimUser;
-import ac.grim.grimac.api.event.GrimEvent;
-import ac.grim.grimac.api.event.GrimEventListener;
 import ac.grim.grimac.api.event.events.CommandExecuteEvent;
 import ac.grim.grimac.api.event.events.FlagEvent;
 import ac.grim.grimac.api.plugin.BasicGrimPlugin;
@@ -13,8 +11,6 @@ import me.justindevb.anticheatreplay.AntiCheatReplay;
 import me.justindevb.anticheatreplay.ListenerBase;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
-import org.bukkit.event.EventHandler;
-import org.bukkit.event.Listener;
 import org.bukkit.plugin.RegisteredServiceProvider;
 
 import java.util.ArrayList;
@@ -59,7 +55,8 @@ public class GrimACListener extends ListenerBase {
 
             alertList.add(p.getUniqueId());
 
-            startRecording(Bukkit.getPlayer(p.getUniqueId()), event.getCheck().getCheckName());
+            Player bukkitPlayer = Bukkit.getPlayer(p.getUniqueId());
+            startRecording(bukkitPlayer, getReplayName(bukkitPlayer, event.getCheck().getCheckName()));
 
         });
 

--- a/src/main/java/me/justindevb/anticheatreplay/listeners/PlayerListener.java
+++ b/src/main/java/me/justindevb/anticheatreplay/listeners/PlayerListener.java
@@ -3,7 +3,6 @@ package me.justindevb.anticheatreplay.listeners;
 import me.justindevb.anticheatreplay.api.events.PlayerReportEvent;
 import me.justindevb.anticheatreplay.utils.DiscordWebhook;
 import me.justindevb.anticheatreplay.utils.Messages;
-import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;

--- a/src/main/java/me/justindevb/anticheatreplay/utils/Messages.java
+++ b/src/main/java/me/justindevb/anticheatreplay/utils/Messages.java
@@ -3,7 +3,6 @@ package me.justindevb.anticheatreplay.utils;
 import java.io.File;
 import java.io.IOException;
 
-import org.bukkit.Bukkit;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 

--- a/src/main/java/me/justindevb/anticheatreplay/utils/UpdateChecker.java
+++ b/src/main/java/me/justindevb/anticheatreplay/utils/UpdateChecker.java
@@ -7,7 +7,6 @@ import java.util.Scanner;
 import java.util.function.Consumer;
 
 import me.justindevb.anticheatreplay.AntiCheatReplay;
-import org.bukkit.Bukkit;
 import org.bukkit.plugin.java.JavaPlugin;
 
 //From: https://www.spigotmc.org/wiki/creating-an-update-checker-that-checks-for-updates


### PR DESCRIPTION
## Summary

Fixes recordings silently failing after the first anticheat trigger. Users reported that the first punishment generated a recording but subsequent ones did not.

## Root Causes

### 1. Thread-unsafe `alertList` / `punishList`
`LinkedList<UUID>` was accessed from both the main thread (event handlers) and async threads (`runLaterAsync` in `runLogic`). Concurrent access corrupts `LinkedList` internals, causing `remove()` to silently fail. The UUID stays stuck in `alertList`, and the `if (alertList.contains(uuid)) return` guard blocks all future recordings for that player.

**Fix:** Replaced with `ConcurrentLinkedDeque<UUID>`.

### 2. No cleanup guarantee in `runLogic`
`alertList.remove()` and `punishList.remove()` were scattered across multiple code paths. If any exception occurred, or if `saveEvent.isCancelled()` returned true, the UUID was never removed — permanently blocking that player from being recorded again.

**Fix:** Wrapped the entire block in `try/finally` so both lists are always cleaned up.

### 3. GrimACListener missing `getReplayName()`
The Grim listener passed the raw check name (e.g. `"Speed"`) as the recording session name instead of calling `getReplayName()`. BetterReplay's `RecorderManager` keys active sessions by name — a second flag with the same check name would be rejected by `activeSessions.containsKey(name)`.

**Fix:** Now calls `getReplayName(player, checkName)` which includes the player name + timestamp + salt.

### 4. Recording auto-save race condition
ACR passed the recording duration to BetterReplay, which would auto-stop the session with `save=true` when duration expired. This raced with ACR's own `runLogic` timer that decides whether to save or discard. If BetterReplay's timer fired first, ACR's subsequent `stopRecording()` call found no session to stop.

**Fix:** Pass `0` (infinite duration) to BetterReplay so ACR has full control over the stop/save lifecycle.

### 5. Null check order bug
`!p.isOnline() || p == null` would throw NPE if `p` were null. Fixed to `p == null || !p.isOnline()`.

## Files Changed

- `ListenerBase.java` — All core fixes
- `GrimACListener.java` — Replay name fix + unused import cleanup
- `PlayerListener.java`, `Messages.java`, `UpdateChecker.java` — Unused import cleanup
