### PR TITLE
Fix Spartan API NoSuchMethodError for getHackType()

### DIFF
--- a/src/main/java/me/justindevb/anticheatreplay/listeners/AntiCheats/SpartanListener.java
+++ b/src/main/java/me/justindevb/anticheatreplay/listeners/AntiCheats/SpartanListener.java
@@ -27,7 +27,7 @@ public class SpartanListener extends ListenerBase implements Listener {
 
 		alertList.add(p.getUniqueId());
 
-		startRecording(p, getReplayName(p, event.getHackType().toString()));
+		startRecording(p, getReplayName(p, getHackTypeName(event)));
 	}
 
 	@EventHandler(priority = EventPriority.HIGHEST)
@@ -36,6 +36,20 @@ public class SpartanListener extends ListenerBase implements Listener {
 
 		if (!punishList.contains(p.getUniqueId()))
 			punishList.add(p.getUniqueId());
+	}
+
+	/**
+	 * Uses reflection to call getHackType() to avoid NoSuchMethodError when
+	 * the Spartan API return type changes between versions
+	 * (me.vagdedes.spartan.system.Enums$HackType vs ai.idealistic.spartan.abstraction.check.CheckEnums$HackType).
+	 */
+	private String getHackTypeName(PlayerViolationEvent event) {
+		try {
+			Object hackType = event.getClass().getMethod("getHackType").invoke(event);
+			return hackType != null ? hackType.toString() : "unknown";
+		} catch (Exception e) {
+			return "unknown";
+		}
 	}
 
 }


### PR DESCRIPTION
## Problem

AntiCheatReplay crashes with a `NoSuchMethodError` when handling Spartan's `PlayerViolationEvent`:

`
java.lang.NoSuchMethodError: 'me.vagdedes.spartan.system.Enums me.vagdedes.spartan.api.PlayerViolationEvent.getHackType()'
`

This occurs because Spartan has been repackaged from `me.vagdedes.spartan` to `ai.idealistic.spartan`, and the return type of `getHackType()` changed from `Enums.HackType` to `CheckEnums.HackType`. Since the JVM treats the return type as part of the method descriptor, the compiled call no longer matches at runtime even though a method named `getHackType()` still exists on the event.

## Fix

Replace the direct `event.getHackType().toString()` call in `SpartanListener` with a reflection-based helper that invokes `getHackType()` without binding to a specific return type. This makes the plugin compatible with both old and new Spartan versions.

## Testing

- Verified the project compiles cleanly with `mvn compile`.
- The reflection call gracefully falls back to `unknown` if the method is absent or fails, so the plugin will never crash on this code path regardless of Spartan version.