### PR TITLE
Fix duplicate recording starts with multi-AC and reload scenarios

### DIFF
--- a/src/main/java/me/justindevb/anticheatreplay/AntiCheatReplay.java
+++ b/src/main/java/me/justindevb/anticheatreplay/AntiCheatReplay.java
@@ -19,6 +19,7 @@ import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 
 public class AntiCheatReplay extends JavaPlugin {
@@ -26,6 +27,7 @@ public class AntiCheatReplay extends JavaPlugin {
     private static AntiCheatReplay instance = null;
     private final Map<AntiCheat, ListenerBase> activeListeners = new EnumMap<>(AntiCheat.class);
     private final HashMap<UUID, PlayerCache> playerCache = new HashMap<>();
+    private final Set<UUID> activeRecordings = ConcurrentHashMap.newKeySet();
     private AntiCheat anticheat = null;
     private FoliaLib foliaLib;
 
@@ -57,6 +59,7 @@ public class AntiCheatReplay extends JavaPlugin {
     @Override
     public void onDisable() {
         this.playerCache.clear();
+        this.activeRecordings.clear();
 
         // Properly disinitialize listeners
         for (ListenerBase value : this.activeListeners.values()) {
@@ -79,11 +82,20 @@ public class AntiCheatReplay extends JavaPlugin {
      * Find a compatible AntiCheat and register support for it
      */
     private void findCompatAntiCheat() {
+        this.activeListeners.clear();
+        this.anticheat = null;
+
         for (AntiCheat value : AntiCheat.values()) {
             if (value.getChecker().apply(this)) {
                 final ListenerBase base = value.getInstantiator().apply(this);
+
+                if (base == null) {
+                    continue;
+                }
+
                 activeListeners.put(value, base);
                 this.anticheat = value;
+                break;
             }
         }
 
@@ -142,11 +154,21 @@ public class AntiCheatReplay extends JavaPlugin {
                 value.disinit();
             }
         }
+        this.activeListeners.clear();
+        this.activeRecordings.clear();
         reloadConfig();
         findCompatAntiCheat();
         new Messages();
         log("Reloaded Messages.yml", false);
         log("Reloaded config.yml", false);
+    }
+
+    public boolean tryStartRecording(UUID uuid) {
+        return this.activeRecordings.add(uuid);
+    }
+
+    public void finishRecording(UUID uuid) {
+        this.activeRecordings.remove(uuid);
     }
 
     private void initBstats() {

--- a/src/main/java/me/justindevb/anticheatreplay/ListenerBase.java
+++ b/src/main/java/me/justindevb/anticheatreplay/ListenerBase.java
@@ -73,23 +73,33 @@ public abstract class ListenerBase {
 	 * @param replayName  Name of the recording when saving
 	 */
 	protected void startRecording(Player p, String replayName) {
-		RecordingStartEvent startEvent = new RecordingStartEvent(p, replayName);
-
-
-		acReplay.getFoliaLib().getScheduler().runNextTick(task -> {
-			Bukkit.getPluginManager().callEvent(startEvent);
-		});
-
-		if (startEvent.isCancelled())
+		if (p == null)
 			return;
 
-		acReplay.log("Starting recording of player: " + p.getName(), false);
-		acReplay.getFoliaLib().getScheduler().runAtEntity(p, task -> {
-			replay.startRecording(replayName, List.of(getNearbyPlayers(p)), Math.toIntExact(delay * 60));
+		if (!acReplay.tryStartRecording(p.getUniqueId()))
+			return;
+
+		acReplay.getFoliaLib().getScheduler().runNextTick(task -> {
+			if (!p.isOnline()) {
+				acReplay.finishRecording(p.getUniqueId());
+				return;
+			}
+
+			RecordingStartEvent startEvent = new RecordingStartEvent(p, replayName);
+			Bukkit.getPluginManager().callEvent(startEvent);
+
+			if (startEvent.isCancelled()) {
+				acReplay.finishRecording(p.getUniqueId());
+				return;
+			}
+
+			acReplay.log("Starting recording of player: " + p.getName(), false);
+			acReplay.getFoliaLib().getScheduler().runAtEntity(p, entityTask -> {
+				replay.startRecording(replayName, List.of(getNearbyPlayers(p)), Math.toIntExact(delay * 60));
+			});
+
+			runLogic(p, replayName);
 		});
-
-
-		runLogic(p, replayName);
 	}
 
 	/**
@@ -166,6 +176,7 @@ public abstract class ListenerBase {
 			} finally {
 				alertList.remove(p.getUniqueId());
 				punishList.remove(p.getUniqueId());
+				acReplay.finishRecording(p.getUniqueId());
 			}
 	},20L * 60L * delay);
 	}

--- a/src/main/java/me/justindevb/anticheatreplay/listeners/AntiCheats/GrimACListener.java
+++ b/src/main/java/me/justindevb/anticheatreplay/listeners/AntiCheats/GrimACListener.java
@@ -13,12 +13,16 @@ import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.RegisteredServiceProvider;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 
 public class GrimACListener extends ListenerBase {
 	
     private List<String> punishCommands = new ArrayList<>();
+    private GrimPlugin grimPlugin;
+    private Object grimEventBus;
 
     public GrimACListener(AntiCheatReplay acReplay) {
         super(acReplay);
@@ -37,7 +41,7 @@ public class GrimACListener extends ListenerBase {
 
         initGrimSpecificConfig();
 
-        GrimPlugin plugin = new BasicGrimPlugin(
+        this.grimPlugin = new BasicGrimPlugin(
                 this.acReplay.getLogger(),
                 this.acReplay.getDataFolder(),
                 acReplay.getDescription().getVersion(),
@@ -46,8 +50,9 @@ public class GrimACListener extends ListenerBase {
         );
 
         GrimAbstractAPI api = provider.getProvider();
+        this.grimEventBus = api.getEventBus();
 
-        api.getEventBus().subscribe(plugin, FlagEvent.class, event -> {
+        api.getEventBus().subscribe(grimPlugin, FlagEvent.class, event -> {
             GrimUser p = event.getPlayer();
 
             if (alertList.contains(p.getUniqueId()))
@@ -60,7 +65,7 @@ public class GrimACListener extends ListenerBase {
 
         });
 
-        api.getEventBus().subscribe(plugin, CommandExecuteEvent.class, event -> {
+        api.getEventBus().subscribe(grimPlugin, CommandExecuteEvent.class, event -> {
             if (!parseCommand(event.getCommand())) {
                 return;
             }
@@ -72,6 +77,15 @@ public class GrimACListener extends ListenerBase {
         });
 
 
+    }
+
+    @Override
+    public void disinit() {
+        if (grimEventBus == null || grimPlugin == null)
+            return;
+
+        invokeIfPresent(grimEventBus, "unsubscribe");
+        invokeIfPresent(grimEventBus, "unregister");
     }
 
 
@@ -121,6 +135,16 @@ public class GrimACListener extends ListenerBase {
 
     private void initGrimSpecificConfig() {
         this.punishCommands = acReplay.getConfig().getStringList("Grim.Punish-Commands");
+    }
+
+    private void invokeIfPresent(Object target, String methodName) {
+        try {
+            Method method = target.getClass().getMethod(methodName, GrimPlugin.class);
+            method.invoke(target, grimPlugin);
+        } catch (NoSuchMethodException ignored) {
+        } catch (IllegalAccessException | InvocationTargetException ex) {
+            acReplay.log("Unable to unregister Grim listener via " + methodName + ": " + ex.getMessage(), true);
+        }
     }
 
 }

--- a/src/main/java/me/justindevb/anticheatreplay/listeners/AntiCheats/KarhuListener.java
+++ b/src/main/java/me/justindevb/anticheatreplay/listeners/AntiCheats/KarhuListener.java
@@ -9,11 +9,25 @@ import me.liwk.karhu.api.event.KarhuEvent;
 import me.liwk.karhu.api.event.impl.KarhuAlertEvent;
 import me.liwk.karhu.api.event.impl.KarhuBanEvent;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
 public class KarhuListener extends ListenerBase implements me.liwk.karhu.api.event.KarhuListener {
 
 	public KarhuListener(AntiCheatReplay acReplay) {
 		super(acReplay);
 		KarhuAPI.getEventRegistry().addListener(this);
+	}
+
+	@Override
+	public void disinit() {
+		Object registry = KarhuAPI.getEventRegistry();
+		if (registry == null)
+			return;
+
+		invokeIfPresent(registry, "removeListener");
+		invokeIfPresent(registry, "unregisterListener");
+		invokeIfPresent(registry, "unregister");
 	}
 
 	public void onEvent(KarhuEvent event) {
@@ -32,6 +46,16 @@ public class KarhuListener extends ListenerBase implements me.liwk.karhu.api.eve
 
 			if (!punishList.contains(p.getUniqueId()))
 				punishList.add(p.getUniqueId());
+		}
+	}
+
+	private void invokeIfPresent(Object target, String methodName) {
+		try {
+			Method method = target.getClass().getMethod(methodName, me.liwk.karhu.api.event.KarhuListener.class);
+			method.invoke(target, this);
+		} catch (NoSuchMethodException ignored) {
+		} catch (IllegalAccessException | InvocationTargetException ex) {
+			acReplay.log("Unable to unregister Karhu listener via " + methodName + ": " + ex.getMessage(), true);
 		}
 	}
 

--- a/src/main/java/me/justindevb/anticheatreplay/listeners/AntiCheats/KauriListener.java
+++ b/src/main/java/me/justindevb/anticheatreplay/listeners/AntiCheats/KauriListener.java
@@ -23,6 +23,11 @@ public class KauriListener extends ListenerBase implements KauriEvent {
 	}
 
 	@Override
+	public void disinit() {
+		KauriAPI.INSTANCE.unregisterEvents(acReplay);
+	}
+
+	@Override
 	public FlagResult onFlag(Player p, KauriCheck check, String information, boolean cancelled) {
 
 		if (alertList.contains(p.getUniqueId()))


### PR DESCRIPTION
# Fix duplicate recording starts with multi-AC and reload scenarios

## Summary
This PR fixes a bug where one player violation could trigger multiple recordings (and repeated "Starting recording" / "Not saving recording" logs), especially when more than one anti-cheat integration was active or when custom event-bus listeners were duplicated across reloads.

## Root cause
1. The plugin could register more than one supported anti-cheat listener at once, allowing multiple integrations to react to the same player behavior.
2. Recording start dedupe was not global/atomic across listener paths.
3. Custom event-bus integrations (Grim, Karhu, Kauri) were not consistently unregistered on reload, so listeners could stack.

## What changed
### 1) Enforce one active anti-cheat integration
- Detection now stops at the first compatible anti-cheat and does not register additional integrations.
- Avoids duplicate trigger paths when multiple anti-cheat plugins are installed.

### 2) Add global atomic per-player recording lock
- Added plugin-level active recording tracking with:
  - `tryStartRecording(UUID)`
  - `finishRecording(UUID)`
- `startRecording(...)` now acquires lock before starting and releases lock on all exit paths.
- Prevents duplicate starts for the same player even if multiple callbacks race.

### 3) Add explicit custom listener cleanup on reload/disable
- Added `disinit()` cleanup for:
  - `GrimACListener` (unsubscribe/unregister from Grim event bus)
  - `KarhuListener` (remove/unregister listener from Karhu event registry)
  - `KauriListener` (unregister Kauri events for this plugin)
- Includes compatibility fallbacks for differing API method names where needed.

## Validation
- `mvn -q -DskipTests compile` passed after each change set.
- IDE diagnostics report no errors in edited files.

## Impact
- Fixes duplicate recording creation and duplicate log spam for the same player event.
- Reduces reload-related listener stacking for custom integrations.
- Keeps behavior unchanged for normal single-integration recording flow.

## Files touched
- `src/main/java/me/justindevb/anticheatreplay/AntiCheatReplay.java`
- `src/main/java/me/justindevb/anticheatreplay/ListenerBase.java`
- `src/main/java/me/justindevb/anticheatreplay/listeners/AntiCheats/GrimACListener.java`
- `src/main/java/me/justindevb/anticheatreplay/listeners/AntiCheats/KarhuListener.java`
- `src/main/java/me/justindevb/anticheatreplay/listeners/AntiCheats/KauriListener.java`