### PR TITLE
Fix nearby player recording targets

### DIFF
--- a/src/main/java/me/justindevb/anticheatreplay/ListenerBase.java
+++ b/src/main/java/me/justindevb/anticheatreplay/ListenerBase.java
@@ -95,7 +95,7 @@ public abstract class ListenerBase {
 
 			acReplay.log("Starting recording of player: " + p.getName(), false);
 			acReplay.getFoliaLib().getScheduler().runAtEntity(p, entityTask -> {
-				replay.startRecording(replayName, List.of(getNearbyPlayers(p)), Math.toIntExact(delay * 60));
+				replay.startRecording(replayName, getNearbyPlayers(p), Math.toIntExact(delay * 60));
 			});
 
 			runLogic(p, replayName);
@@ -188,31 +188,21 @@ public abstract class ListenerBase {
 	 * @param p
 	 * @return
 	 */
-	private Player[] getNearbyPlayers(Player p) {
+	private Collection<Player> getNearbyPlayers(Player p) {
 		final List<Player> nearbyPlayers = new ArrayList<>();
-		int i = 0;
+		nearbyPlayers.add(p);
 		final Collection<Entity> entites = p.getWorld().getNearbyEntities(p.getLocation(), PLAYER_RANGE, PLAYER_RANGE,
 				PLAYER_RANGE);
 
 		for (final Entity e : entites)
 			if (e instanceof Player) {
-				nearbyPlayers.add((Player) e);
-				i++;
+				Player nearbyPlayer = (Player) e;
+				if (!nearbyPlayer.getUniqueId().equals(p.getUniqueId())) {
+					nearbyPlayers.add(nearbyPlayer);
+				}
 			}
 
-		if (i == 0) {
-			Player[] player = new Player[1];
-			player[0] = p;
-			return player;
-		}
-
-		final Player[] players = new Player[i];
-		players[0] = p;
-
-		for (int j = 1; i > 1 && j < nearbyPlayers.size(); j++)
-			players[j] = nearbyPlayers.get(j);
-
-		return players;
+		return nearbyPlayers;
 
 	}
 


### PR DESCRIPTION
## Summary

This fixes nearby-player capture targets when starting a recording from AntiCheatReplay.

## Root Cause

AntiCheatReplay was wrapping the nearby player result in `List.of(...)` when calling `ReplayManager.startRecording(...)`, which produced a nested collection shape instead of the player collection BetterReplay expects.

The nearby-player helper also built its result incorrectly:
- it allocated the array based only on nearby players
- it inserted the recorded player at index `0`
- it skipped the first nearby player when copying results

That meant recordings could drop the first nearby player, and in the common case of a single nearby observer the recording target set collapsed to only the reported player.

## Changes

- pass the nearby player collection directly into `startRecording(...)`
- return a `Collection<Player>` from the helper instead of a manually assembled array
- always include the recorded player
- include distinct nearby players without duplicating the target player

## Validation

- `mvn -DskipTests compile`

## Notes

This does not change the BetterReplay dependency configuration in `pom.xml`.
It keeps AntiCheatReplay compatible with the currently bundled `bin/BetterReplay-1.4.0.jar` while fixing the broken nearby-player target assembly in this plugin.
