### PR TITLE
Fix /report recordings and refresh BetterReplay docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-This plugin allows for you to record a player that your AntiCheat has punished from your server and watch the hack at a later time. The hacker could be the only person online and you would still have video evidence of them hacking.
+This plugin records suspicious players so you can review the incident later in BetterReplay. Recordings can start from supported AntiCheat alerts and punishments, and staff can also trigger a recording manually with `/report`.
 
 See the [Changelog](CHANGELOG.md) for a full history of changes across all versions.
 
@@ -42,9 +42,9 @@ With this you can have video proof of someone hacking on your server when they a
 Features Discord Integration. Optionally send a message to a Discord Channel whenever a recording is created.
 ![Discord Webhook Example](https://www.spigotmc.org/attachments/capture-png.665322/)
 
-Requires a supported AntiCheat and AdvancedReplay to be installed and running on your server.
+Requires a supported AntiCheat and BetterReplay to be installed and running on your server.
 
-NOTE: Your AntiCheat has to be configured to punish someone in order to record. If players never get punished you will not get a recording.
+NOTE: AntiCheat-driven recordings still depend on the integrations your AntiCheat exposes. For most integrations, a flag starts the recording and a punish event causes it to be saved. The `/report` command can also start and save a recording without relying on a punish event.
 
 
 ### Setup:
@@ -52,10 +52,10 @@ NOTE: Your AntiCheat has to be configured to punish someone in order to record. 
 - Soaroma: Set `enableAPI` in Soaroma's config to "true"
 - Sparky: Set `API.Events` in Sparky's config to "true"
 
-For best results, follow this configuration guide for Advanced Replay:
+For best results, follow this configuration guide for BetterReplay:
 
 Enable MySQL to store the files (This plugin can generate a lot of recordings if you have a lot of hackers. Depending on your recording length this can take up quite a bit of space.)
-   In AdvancedReplay config.yml change the following values:
+  In BetterReplay `config.yml` change the following values:
 ```
    cleanup_replays: 10 # This makes replays delete when they're 10 days old
    hide_players: true
@@ -71,37 +71,47 @@ Enable MySQL to store the files (This plugin can generate a lot of recordings if
 ### Default Configuration:
 ```YAML
 General:
-Overwrite: false  #Should we overwrite a recording if a player did the same hack on the same date?
-Check-Update: true  #Be notified when this plugin updates
-Nearby-Range: 30     #How far to look for nearby players to include in the recording? NOTE: The formula is 1/2 of what you put here in each. So it will be 15 blocks in each +x and -x for a total of 30 blocks, etc.
-Recording-Length: 2 #Length in minutes of a recording. Recording will not be created until this time has passed from the start of a recording.
+  Overwrite: false  # Should we overwrite a recording if a player did the same hack on the same date?
+  Check-Update: true  # Be notified when this plugin updates
+  Nearby-Range: 30  # How far to look for nearby players to include in the recording?
+  Recording-Length: 2  # Length in minutes of a recording.
+  Notify-Staff: true  # Notify staff with AntiCheatReplay.recording-notify when a replay is saved.
+  Save-Recording-On-Disconnect: false
+  Always-Save-Recording: false
+  Report-Cooldown: 3  # Cooldown in minutes between reports per player.
+  Report-Enabled: true
 Vulcan:
-Disabled-Recordings: #Any checks you do not want to record. These are examples, replace/add as many as you want NOTE: Must be lowercase
-- timer
-- strafe
-  Themis:
-  Disabled-Actions:   #Themis Actions to disable, refer to Themis config.yml
-- notify
-  Discord: # Send a recording notification to a Discord Channel
+  Disabled-Recordings: # Any checks you do not want to record. Must be lowercase.
+    - timer
+    - strafe
+Themis:
+  Disabled-Actions:   # Themis actions to disable, refer to the Themis config.yml.
+    - notify
+Discord: # Send a recording notification to a Discord channel.
   Enabled: true
   Webhook: Enter webhook here
-  Avatar: https://i.imgur.com/JPG1Kwk.png     #Default Vulcan avatar, feel free to change this
+  Avatar: https://i.imgur.com/JPG1Kwk.png  # Default Vulcan avatar, feel free to change this.
   Username: VulcanReplay
   Server-Name: Server
 ```
 ### Usage:
 ```
-Most commands and permissions are handled by AdvancedReplay The only command AntiCheatReplay adds is a reload command
+Most replay management commands are handled by BetterReplay. AntiCheatReplay adds a reload command and an optional player report command.
 
 Basic usage:
-/replay list Will print a list of recordings
-/replay play <recording> Play a recording
-/replay delete <recording> Deletes a recording
-/replay reload vulcanreplay.reload Reload AntiCheatReplay
-```
-### Known Issues:
+/replay list                          # List recordings
+/replay play <recording>              # Play a recording
+/replay delete <recording>            # Delete a recording
+/replayreload                         # Reload AntiCheatReplay
+/report <player> [reason]             # Start or mark a recording to be saved for the reported player
 
-Recording does not show any mobs/entities other than Players. You may see a player take damage in a recording from what appears to be nothing, but it could be a mob. Again, this is an issue that the AdvancedReplay developer has to fix.
+Permissions:
+AntiCheatReplay.reload                # Use /replayreload
+AntiCheatReplay.report                # Use /report
+AntiCheatReplay.report-notify         # Receive staff notifications when someone files a report
+AntiCheatReplay.reportImmune          # Prevent a player from being reported
+AntiCheatReplay.recording-notify      # Receive staff notifications when a replay is saved
+```
 
 
 ### Discord

--- a/src/main/java/me/justindevb/anticheatreplay/AntiCheatReplay.java
+++ b/src/main/java/me/justindevb/anticheatreplay/AntiCheatReplay.java
@@ -20,6 +20,7 @@ import org.bukkit.plugin.java.JavaPlugin;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.logging.Level;
 
 public class AntiCheatReplay extends JavaPlugin {
@@ -27,7 +28,9 @@ public class AntiCheatReplay extends JavaPlugin {
     private static AntiCheatReplay instance = null;
     private final Map<AntiCheat, ListenerBase> activeListeners = new EnumMap<>(AntiCheat.class);
     private final HashMap<UUID, PlayerCache> playerCache = new HashMap<>();
-    private final Set<UUID> activeRecordings = ConcurrentHashMap.newKeySet();
+    private final Map<UUID, String> activeRecordings = new ConcurrentHashMap<>();
+    private final ConcurrentLinkedDeque<UUID> alertList = new ConcurrentLinkedDeque<>();
+    private final ConcurrentLinkedDeque<UUID> punishList = new ConcurrentLinkedDeque<>();
     private AntiCheat anticheat = null;
     private FoliaLib foliaLib;
 
@@ -60,6 +63,8 @@ public class AntiCheatReplay extends JavaPlugin {
     public void onDisable() {
         this.playerCache.clear();
         this.activeRecordings.clear();
+        this.alertList.clear();
+        this.punishList.clear();
 
         // Properly disinitialize listeners
         for (ListenerBase value : this.activeListeners.values()) {
@@ -156,6 +161,8 @@ public class AntiCheatReplay extends JavaPlugin {
         }
         this.activeListeners.clear();
         this.activeRecordings.clear();
+        this.alertList.clear();
+        this.punishList.clear();
         reloadConfig();
         findCompatAntiCheat();
         new Messages();
@@ -163,12 +170,24 @@ public class AntiCheatReplay extends JavaPlugin {
         log("Reloaded config.yml", false);
     }
 
-    public boolean tryStartRecording(UUID uuid) {
-        return this.activeRecordings.add(uuid);
+    public boolean tryStartRecording(UUID uuid, String replayName) {
+        return this.activeRecordings.putIfAbsent(uuid, replayName) == null;
+    }
+
+    public String getActiveRecordingName(UUID uuid) {
+        return this.activeRecordings.get(uuid);
     }
 
     public void finishRecording(UUID uuid) {
         this.activeRecordings.remove(uuid);
+    }
+
+    public ConcurrentLinkedDeque<UUID> getAlertList() {
+        return this.alertList;
+    }
+
+    public ConcurrentLinkedDeque<UUID> getPunishList() {
+        return this.punishList;
     }
 
     private void initBstats() {

--- a/src/main/java/me/justindevb/anticheatreplay/ListenerBase.java
+++ b/src/main/java/me/justindevb/anticheatreplay/ListenerBase.java
@@ -52,12 +52,14 @@ public abstract class ListenerBase {
 	private int BLUE = 0;
 
 
-	protected ConcurrentLinkedDeque<UUID> alertList = new ConcurrentLinkedDeque<>();
-	protected ConcurrentLinkedDeque<UUID> punishList = new ConcurrentLinkedDeque<>();
+	protected ConcurrentLinkedDeque<UUID> alertList;
+	protected ConcurrentLinkedDeque<UUID> punishList;
 
 	public ListenerBase(AntiCheatReplay acReplay) {
 		this.acReplay = acReplay;
 		this.replay = ReplayAPI.get();
+		this.alertList = acReplay.getAlertList();
+		this.punishList = acReplay.getPunishList();
 
 		initConfigFields();
 	}
@@ -76,7 +78,7 @@ public abstract class ListenerBase {
 		if (p == null)
 			return;
 
-		if (!acReplay.tryStartRecording(p.getUniqueId()))
+		if (!acReplay.tryStartRecording(p.getUniqueId(), replayName))
 			return;
 
 		acReplay.getFoliaLib().getScheduler().runNextTick(task -> {
@@ -108,21 +110,22 @@ public abstract class ListenerBase {
 	 * @param target
 	 * @param reason
 	 */
-	protected void reportPlayer(Player reporter, Player target, String reason) {
-		if (alertList.contains(target.getUniqueId()))
+	protected void reportPlayer(Player reporter, Player target, String reason, String replayName) {
+		if (target == null)
 			return;
-		alertList.add(target.getUniqueId());
-		String replayName = getReplayName(target, "report");
-		acReplay.log("Starting recording of player: " + target.getName(), false);
 
-		acReplay.getFoliaLib().getScheduler().runLaterAsync(() -> {
-			acReplay.log("Saved a player report:", false);
-			acReplay.log(reporter.getName() + " reported " + target.getName() + " for " + reason, false);
+		UUID targetId = target.getUniqueId();
 
+		if (!punishList.contains(targetId))
+			punishList.add(targetId);
 
-			if (alertList.contains(target.getUniqueId()))
-				alertList.remove(target.getUniqueId());
-		}, 20L * 60L * delay);
+		acReplay.log(reporter.getName() + " reported " + target.getName() + " for " + reason, false);
+
+		if (alertList.contains(targetId))
+			return;
+
+		alertList.add(targetId);
+		startRecording(target, replayName);
 	}
 
 	protected void saveRecording() {

--- a/src/main/java/me/justindevb/anticheatreplay/api/events/PlayerReportEvent.java
+++ b/src/main/java/me/justindevb/anticheatreplay/api/events/PlayerReportEvent.java
@@ -13,11 +13,13 @@ public class PlayerReportEvent extends Event implements Cancellable {
     private Player reporter;
     private Player target;
     private String reason;
+    private String recordingName;
 
-    public PlayerReportEvent(Player reporter, Player target, String reason) {
+    public PlayerReportEvent(Player reporter, Player target, String reason, String recordingName) {
         this.reporter = reporter;
         this.target = target;
         this.reason = reason;
+        this.recordingName = recordingName;
         this.isCancelled = false;
     }
 
@@ -47,6 +49,10 @@ public class PlayerReportEvent extends Event implements Cancellable {
      */
     public String getReason() {
         return this.reason;
+    }
+
+    public String getRecordingName() {
+        return this.recordingName;
     }
 
     @Override

--- a/src/main/java/me/justindevb/anticheatreplay/commands/ReportCommand.java
+++ b/src/main/java/me/justindevb/anticheatreplay/commands/ReportCommand.java
@@ -51,17 +51,18 @@ public class ReportCommand extends ListenerBase implements CommandExecutor {
             return true;
         }
 
-        if (Bukkit.getPlayer(strings[0]) == null || !Bukkit.getPlayer(strings[0]).isOnline()) {
+        Player target = Bukkit.getPlayer(strings[0]);
+        if (target == null || !target.isOnline()) {
             p.sendMessage(ChatColor.DARK_RED + Messages.REPORT_OFFLINE_ERROR);
             return true;
         }
 
-        if (Bukkit.getPlayer(strings[0]).getName().contentEquals(p.getName())) {
+        if (target.getName().contentEquals(p.getName())) {
             p.sendMessage(ChatColor.DARK_RED + Messages.COMMAND_REPORT_SELF_REPORT);
             return true;
         }
 
-        if (Bukkit.getPlayer(strings[0]).hasPermission("AntiCheatReplay.reportImmune")) {
+        if (target.hasPermission("AntiCheatReplay.reportImmune")) {
             p.sendMessage(ChatColor.DARK_RED + Messages.REPORT_IMMUNE);
             return true;
         }
@@ -74,7 +75,11 @@ public class ReportCommand extends ListenerBase implements CommandExecutor {
                 reason += strings[i] + " ";
         }
 
-        PlayerReportEvent reportEvent = new PlayerReportEvent(p, Bukkit.getPlayer(strings[0]), reason);
+        String replayName = acReplay.getActiveRecordingName(target.getUniqueId());
+        if (replayName == null)
+            replayName = getReplayName(target, "report");
+
+        PlayerReportEvent reportEvent = new PlayerReportEvent(p, target, reason, replayName);
         acReplay.getFoliaLib().getScheduler().runNextTick(task -> {
            Bukkit.getPluginManager().callEvent(reportEvent);
         });
@@ -85,7 +90,7 @@ public class ReportCommand extends ListenerBase implements CommandExecutor {
         String notification = Messages.COMMAND_REPORT_NOTIFY;
         notification = notification
                 .replace("%r", p.getName())
-                .replace("%s", Bukkit.getPlayer(strings[0]).getName())
+                .replace("%s", target.getName())
                 .replace("%t", reason);
 
         for (Player player : Bukkit.getOnlinePlayers()) {
@@ -93,7 +98,7 @@ public class ReportCommand extends ListenerBase implements CommandExecutor {
                 player.sendMessage(ChatColor.GOLD + notification);
         }
 
-        reportPlayer(p, Bukkit.getPlayer(strings[0]), reason);
+        reportPlayer(p, target, reason, replayName);
 
         p.sendMessage(ChatColor.DARK_GREEN + Messages.REPORT_SUBMITTED);
 

--- a/src/main/java/me/justindevb/anticheatreplay/listeners/PlayerListener.java
+++ b/src/main/java/me/justindevb/anticheatreplay/listeners/PlayerListener.java
@@ -61,7 +61,7 @@ public class PlayerListener implements Listener {
 		Player target = event.getTarget();
 		String reason = event.getReason();
 
-		sendDiscordWebhook(target.getName() + "-report", reason, reporter, target);
+		sendDiscordWebhook(event.getRecordingName(), reason, reporter, target);
 
 
 	}


### PR DESCRIPTION
## Summary
- make `/report` start a new recording or reuse an active one and ensure the replay is marked to be saved
- share alert, punish, and active recording state across the plugin so command-driven and anti-cheat-driven flows stay in sync
- carry the replay name through `PlayerReportEvent` so report notifications point to the replay that was actually recorded
- update the README to replace stale `AdvancedReplay` references with `BetterReplay` and document `/report`

## Testing
- `mvn -f "F:\Minecraft\Forks\AntiCheatReplay\pom.xml" -DskipTests compile`
