### PR TITLE
Fix startup crash when no supported AntiCheat is installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Fixed
+- Fix startup crash when no supported AntiCheat is installed by stopping initialization after the plugin disables itself (branch: fix/no-anticheat-graceful-disable)
 - Fix Spartan API `NoSuchMethodError` for `getHackType()` (branch: fix/spartan-api-compat)
 - Fix recordings failing after first anticheat trigger (branch: fix/recording-state-bugs)
 

--- a/src/main/java/me/justindevb/anticheatreplay/AntiCheatReplay.java
+++ b/src/main/java/me/justindevb/anticheatreplay/AntiCheatReplay.java
@@ -49,6 +49,9 @@ public class AntiCheatReplay extends JavaPlugin {
     private void initialInit() {
         foliaLib.getScheduler().runNextTick(task -> {
             checkRequiredPlugins();
+            if (!isEnabled()) {
+                return;
+            }
             registerListener();
             initConfig();
             checkForUpdate();
@@ -194,7 +197,7 @@ public class AntiCheatReplay extends JavaPlugin {
         final int pluginId = 13402;
         Metrics metrics = new Metrics(this, pluginId);
         metrics.addCustomChart(new SimplePie("anticheat", () -> {
-            return this.anticheat.getName();
+            return this.anticheat != null ? this.anticheat.getName() : "none";
         }));
 
         metrics.addCustomChart(new SimplePie("discord-hook", () -> {


### PR DESCRIPTION
﻿## Summary
- Prevent startup from continuing after the plugin disables itself when no supported AntiCheat is installed.
- Make the bStats anti-cheat chart null-safe so it reports `none` instead of throwing.

## Verification
- `mvn -q -DskipTests compile`
